### PR TITLE
Exiting with child's exit status when not alive or watching

### DIFF
--- a/runit.go
+++ b/runit.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
 )
 
 type Runner struct {
@@ -42,6 +41,11 @@ func New(cmdIn string, watchPath string) (*Runner, error) {
 	}
 
 	return runner, nil
+}
+
+// Wait for the running command to complete.
+func (r *Runner) Wait() error {
+	return r.cmd.Wait()
 }
 
 // Run runs the subprocess with optional keep alive
@@ -92,8 +96,8 @@ func (r *Runner) RestartListen() {
 	}
 }
 
-// runCmd starts and waits for a command
-// to complete.
+// runCmd starts the command and doesn't wait
+// for it to complete.
 func (r *Runner) runCmd() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/watch.go
+++ b/watch.go
@@ -101,7 +101,7 @@ func NewRecursiveWatcher(path string) (*RecursiveWatcher, error) {
 func (watcher *RecursiveWatcher) AddFolder(folder string) {
 	err := watcher.Add(folder)
 	if err != nil {
-		log.Println("Error watching: %s %v", folder, err)
+		log.Printf("Error watching: %s %v\n", folder, err)
 	}
 	watcher.Folders <- folder
 }


### PR DESCRIPTION
When alive is false and watch is empty, this will make runit die after the child process exits. runit will exit with the child process exit code.
